### PR TITLE
Callable identity accessors

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,21 @@ $> composer require everzet/persisted-objects
 Use like this:
 
 ```
-$repo = new FileRepository(TEMP_FILE, new AccessorIdentityLocator('getId'));
+$repo = new FileRepository(TEMP_FILE, new AccessorObjectIdentifier('getId'));
+$repo->save($user);
+
+$user === $repo->findById($user->getId());
+
+$repo->clear();
+```
+
+or like this:
+
+
+```
+$repo = new InMemoryRepository(new CallbackObjectIdentifier(
+    function($obj) { return $obj->getFirstname() . $obj->getLastname(); }
+);
 $repo->save($user);
 
 $user === $repo->findById($user->getId());

--- a/src/AccessorObjectIdentifier.php
+++ b/src/AccessorObjectIdentifier.php
@@ -3,7 +3,7 @@
 namespace Everzet\PersistedObjects;
 
 
-class AccessorIdentityLocator implements IdentityLocator
+class AccessorObjectIdentifier implements ObjectIdentifier
 {
     /**
      * @var string

--- a/src/CallbackObjectIdentifier.php
+++ b/src/CallbackObjectIdentifier.php
@@ -2,7 +2,7 @@
 
 namespace Everzet\PersistedObjects;
 
-class CallbackIdentityLocator implements IdentityLocator
+class CallbackObjectIdentifier implements ObjectIdentifier
 {
     /**
      * @var callable

--- a/src/FileRepository.php
+++ b/src/FileRepository.php
@@ -9,7 +9,7 @@ final class FileRepository implements Repository
     private $filename;
     private $identityLocator;
 
-    public function __construct($filename, IdentityLocator $identityLocator)
+    public function __construct($filename, ObjectIdentifier $identityLocator)
     {
         $this->filename = $filename;
         $this->identityLocator = $identityLocator;

--- a/src/InMemoryRepository.php
+++ b/src/InMemoryRepository.php
@@ -7,7 +7,7 @@ final class InMemoryRepository implements Repository
     private $identityLocator;
     private $storage = [];
 
-    public function __construct(IdentityLocator $identityLocator)
+    public function __construct(ObjectIdentifier $identityLocator)
     {
         $this->identityLocator = $identityLocator;
     }

--- a/src/ObjectIdentifier.php
+++ b/src/ObjectIdentifier.php
@@ -2,7 +2,7 @@
 
 namespace Everzet\PersistedObjects;
 
-interface IdentityLocator
+interface ObjectIdentifier
 {
     public function getIdentity($obj);
 }

--- a/tests/AccessorObjectIdentifierTest.php
+++ b/tests/AccessorObjectIdentifierTest.php
@@ -2,24 +2,24 @@
 
 namespace IdentityAccessorTest;
 
-use Everzet\PersistedObjects\AccessorIdentityLocator;
-use Everzet\PersistedObjects\IdentityLocator;
+use Everzet\PersistedObjects\AccessorObjectIdentifier;
+use Everzet\PersistedObjects\ObjectIdentifier;
 
-class AccessorIdentityLocatorTest extends \PHPUnit_Framework_TestCase
+class AccessorObjectIdentifierTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var IdentityLocator
+     * @var ObjectIdentifier
      */
     private $accessor;
 
     function setUp()
     {
-        $this->accessor = new AccessorIdentityLocator('getId');
+        $this->accessor = new AccessorObjectIdentifier('getId');
     }
 
     /** @test */ function shouldBeAnIdentityAccessor()
     {
-        $this->assertInstanceOf('Everzet\PersistedObjects\IdentityLocator', $this->accessor);
+        $this->assertInstanceOf('Everzet\PersistedObjects\ObjectIdentifier', $this->accessor);
     }
 
     /** @test */ function shouldReturnTheRightCallback()
@@ -33,7 +33,7 @@ class AccessorIdentityLocatorTest extends \PHPUnit_Framework_TestCase
 
     /** @test @expectedException Exception */ function shouldThrowIfMethodDoesNotExist()
     {
-        $this->accessor = new AccessorIdentityLocator('getOtherId', 'specificObject');
+        $this->accessor = new AccessorObjectIdentifier('getOtherId', 'specificObject');
 
         $obj = $this->getMock('IdentityAccessorTest\AccessorIdentifiedObject');
 

--- a/tests/CallbackObjectIdentifierTest.php
+++ b/tests/CallbackObjectIdentifierTest.php
@@ -2,13 +2,13 @@
 
 namespace IdentityAccessorTest;
 
-use Everzet\PersistedObjects\IdentityLocator;
-use Everzet\PersistedObjects\CallbackIdentityLocator;
+use Everzet\PersistedObjects\ObjectIdentifier;
+use Everzet\PersistedObjects\CallbackObjectIdentifier;
 
 class CallbackIdentityLocatorTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var IdentityLocator
+     * @var ObjectIdentifier
      */
     private $accessor;
 
@@ -17,13 +17,13 @@ class CallbackIdentityLocatorTest extends \PHPUnit_Framework_TestCase
         $callback = function ($obj) {
             return 1234;
         };
-        $this->accessor = new CallbackIdentityLocator($callback);
+        $this->accessor = new CallbackObjectIdentifier($callback);
     }
 
     /** @test */
     function shouldBeAnIdentityAccessor()
     {
-        $this->assertInstanceOf('Everzet\PersistedObjects\IdentityLocator', $this->accessor);
+        $this->assertInstanceOf('Everzet\PersistedObjects\ObjectIdentifier', $this->accessor);
     }
 
     /** @test */

--- a/tests/FileRepositoryTest.php
+++ b/tests/FileRepositoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Everzet\PersistedObjects\AccessorIdentityLocator;
+use Everzet\PersistedObjects\AccessorObjectIdentifier;
 
 class FileRepositoryTest extends PHPUnit_Framework_TestCase
 {
@@ -132,7 +132,7 @@ class FileRepositoryTest extends PHPUnit_Framework_TestCase
     {
         return new Everzet\PersistedObjects\FileRepository(
             $this->filename,
-            new AccessorIdentityLocator('getId')
+            new AccessorObjectIdentifier('getId')
         );
     }
 }

--- a/tests/InMemoryRepositoryTest.php
+++ b/tests/InMemoryRepositoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Everzet\PersistedObjects\AccessorIdentityLocator;
+use Everzet\PersistedObjects\AccessorObjectIdentifier;
 
 class InMemoryRepositoryTest extends PHPUnit_Framework_TestCase
 {
@@ -92,7 +92,7 @@ class InMemoryRepositoryTest extends PHPUnit_Framework_TestCase
     private function createRepository()
     {
         return new Everzet\PersistedObjects\InMemoryRepository(
-            new AccessorIdentityLocator('getId')
+            new AccessorObjectIdentifier('getId')
         );
     }
 }


### PR DESCRIPTION
Not all developers are familiar with the Reflection API, so requiring ReflectionMethod to be passed as an identity accessor might be confusing to them.

More importantly, it does provide a simple route for objects that have composite identity with separate accessors.

``` php
$repo = new InMemoryRepository(function(Conference $conference){ return $conference->getName() . $conference->getYear(); });
```
