### PR TITLE
Open repositories for extension.

### DIFF
--- a/src/FileRepository.php
+++ b/src/FileRepository.php
@@ -2,7 +2,7 @@
 
 namespace Everzet\PersistedObjects;
 
-final class FileRepository implements Repository
+class FileRepository implements Repository
 {
     private $filename;
     private $identifier;

--- a/src/InMemoryRepository.php
+++ b/src/InMemoryRepository.php
@@ -2,7 +2,7 @@
 
 namespace Everzet\PersistedObjects;
 
-final class InMemoryRepository implements Repository
+class InMemoryRepository implements Repository
 {
     private $identifier;
     private $storage = [];


### PR DESCRIPTION
I think in a fake repository implementation it's actually more convenient to extend the repositories, rather than decorate them.

I don't think there's much harm in using this **in tests**:

```php
class MyFakeUserRepository extends InMemoryRepository implements MyUserRepository
{
}
```

instead of:

```php
class MyFakeUserRepository implements MyUserRepository
{
    private $repository;

    public function __construct(Repository $repository)
    {
        $this->repository = $repository;
    }
}
```

